### PR TITLE
Use minification-safe dependency injection syntax

### DIFF
--- a/slider.js
+++ b/slider.js
@@ -1,5 +1,5 @@
 angular.module('ui.bootstrap-slider', [])
-	.directive('slider', function ($parse, $timeout) {
+	.directive('slider', ['$parse', '$timeout', function ($parse, $timeout) {
 		return {
 			restrict: 'AE',
 			replace: true,
@@ -55,6 +55,6 @@ angular.module('ui.bootstrap-slider', [])
 					}
 				});
 			}
-		}
-	})
+		};
+	}])
 ;


### PR DESCRIPTION
This directive bugs out when minified (i.e. using uglify and mangling). So, just switching to the alternate dependency injection syntax.
