### PR TITLE
The slider complains to the console if the ng-disabled attribute isn't s...

### DIFF
--- a/slider.js
+++ b/slider.js
@@ -72,13 +72,15 @@ angular.module('ui.bootstrap-slider', [])
 					}
 				});
 
-				$scope.$watch(attrs.ngDisabled, function (value) {
-					if (value) {
-						slider.slider('disable');
-					} else {
-						slider.slider('enable');
-					}
-				});
+				if (angular.isDefined(attrs.ngDisabled)) {
+					$scope.$watch(attrs.ngDisabled, function(value) {
+						if (value) {
+							slider.slider('disable');
+						} else {
+							slider.slider('enable');
+						}
+					});
+				}
 			}
 		};
 	}])


### PR DESCRIPTION
...et. This fixes that by checking to make sure ngDisabled is defined before initializing the watch.
