### PR TITLE
Update versions and display formatted tooltip

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -22,7 +22,7 @@
     "tests"
   ],
   "dependencies": {
-    "seiyria-bootstrap-slider": "~3.1.0",
+    "seiyria-bootstrap-slider": "~4.2.0",
     "angular": "~1.2.16"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-bootstrap-slider",
-  "version": "0.0.5",
+  "version": "0.0.8",
   "authors": [
     "Kyle Kemp <kyle@seiyria.com>"
   ],

--- a/slider.js
+++ b/slider.js
@@ -40,7 +40,7 @@ angular.module('ui.bootstrap-slider', [])
 				if (attrs.reversed) options.reversed = attrs.reversed === 'true';
 				if (attrs.enabled) options.enabled = attrs.enabled === 'true';
 				if (attrs.naturalarrowkeys) options.natural_arrow_keys = attrs.naturalarrowkeys === 'true';
-				if (attrs.formater) options.formater = $scope.$eval(attrs.formater);
+				if (attrs.formatter) options.formatter = $scope.$eval(attrs.formatter);
 
 				if (options.range && !options.value) {
 					options.value = [0, 0]; // This is needed, because of value defined at $.fn.slider.defaults - default value 5 prevents creating range slider

--- a/slider.js
+++ b/slider.js
@@ -40,7 +40,11 @@ angular.module('ui.bootstrap-slider', [])
 				if (attrs.reversed) options.reversed = attrs.reversed === 'true';
 				if (attrs.enabled) options.enabled = attrs.enabled === 'true';
 				if (attrs.naturalarrowkeys) options.natural_arrow_keys = attrs.naturalarrowkeys === 'true';
-				if (attrs.formatter) options.formatter = $scope.$eval(attrs.formatter);
+				if (attrs.formatter) {
+          options.formatter = function(val) {
+            return attrs.formatter;
+          }
+        }
 
 				if (options.range && !options.value) {
 					options.value = [0, 0]; // This is needed, because of value defined at $.fn.slider.defaults - default value 5 prevents creating range slider


### PR DESCRIPTION
I updated the version in bower.json to match the tag on Github (0.0.8).

I bumped the seiyria-bootstrap-slider version from 3.1 to 4.2.

I changed the way the `formatter` (previously `formater`) argument is handled so that you can create tooltips like so:

```html
<slider ... formatter="{{ someScopeValue == 0 ? 'Nothing' : 'Value: ' + someScopeValue }}" />
``` 

I'm not sure if this is the best approach though. Perhaps it's better to refer to a function on the scope which also takes a `val` argument, like so:

```html
<slider ... formatter="theFormatter()" />
``` 

```js
scope.theFormatter = function(val) {
  val == 0 ? 'Nothing' : 'Value: ' + val
}
```

This would be more similar to the way seiyria-bootstrap-slider works, but I don't know how to achieve that.
