### PR TITLE
Update dependencies to AngularJS 1.3.8 and bootstrap-slider 4.4.0

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -23,6 +23,6 @@
   ],
   "dependencies": {
     "seiyria-bootstrap-slider": "~v4.8",
-    "angular": "~1.2.16"
+    "angular": "~1.3.15"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-bootstrap-slider",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "authors": [
     "Kyle Kemp <kyle@seiyria.com>"
   ],


### PR DESCRIPTION
We can confirm that angular-bootstrap-slider can work with AngularJS 1.3 and bootstrap-slider 4.4.0 at #38.

This pull request updates depended versions and bumps up angular-bootstrap-slider version.