### PR TITLE
fixed support in angular 1.3

### DIFF
--- a/slider.js
+++ b/slider.js
@@ -93,7 +93,8 @@ angular.module('ui.bootstrap-slider', [])
 
                     if ($scope.formater) options.formater = $scope.$eval($scope.formater);
 
-                    var slider = element.find( ".slider-input" ).eq( 0 );
+                    var slider = $(element).find( ".slider-input" ).eq( 0 );
+                    
                     // check if slider jQuery plugin exists
                     if( $.fn.slider ) {
                         // adding methods to jQuery slider plugin prototype


### PR DESCRIPTION
`angular.element` No longer supports the same query selectors as jQuery, so the directive was not actually finding the slider on the element.  Wrapping the raw angular element with jQuery fixes this.  It should be an ok fix since the supported version of bootstrap-slider requires jQuery anyway.