### PR TITLE
fixed ngDisabled data binding

### DIFF
--- a/slider.js
+++ b/slider.js
@@ -164,7 +164,7 @@ angular.module('ui.bootstrap-slider', [])
                             ngDisabledDeregisterFn = null;
                         }
                         if (angular.isDefined(attrs.ngDisabled)) {
-                            ngDisabledDeregisterFn = $scope.$watch(attrs.ngDisabled, function (value) {
+                            ngDisabledDeregisterFn = $scope.$parent.$watch(attrs.ngDisabled, function (value) {
                                 if (value) {
                                     slider.slider('disable');
                                 }


### PR DESCRIPTION
changes in the result of the expression bound to the ng-disabled attribute haven't been reflected via data binding, e.g.:

`<slider ng-disabled="myController.myCondition">`

fixed it by adding "$parent." after "$scope"