### PR TITLE
Allow use of Angular 1.4.x

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -23,6 +23,6 @@
   ],
   "dependencies": {
     "seiyria-bootstrap-slider": "~v4.8",
-    "angular": "~1.3.15"
+    "angular": "~1.3.15||~1.4.0"
   }
 }


### PR DESCRIPTION
This little PR allows usage of this bower package in projects that use Angular 1.4.x without the need of coping with conflicting version requirements and adding resolutions.
Currently this component looks OK on Angular 1.4.0.