### PR TITLE
prevents errors to be thrown when using the slider as a range slider

### DIFF
--- a/slider.js
+++ b/slider.js
@@ -176,7 +176,11 @@ angular.module('ui.bootstrap-slider', [])
                         // deregister ngModel watcher to prevent memory leaks
                         if (angular.isFunction(ngModelDeregisterFn)) ngModelDeregisterFn();
                         ngModelDeregisterFn = $scope.$watch('ngModel', function (value) {
-                            slider.slider('setValue', parseFloat(value));
+                            if($scope.range){
+                                slider.slider('setValue', value);    
+                            }else{
+                                slider.slider('setValue', parseFloat(value));
+                            }
                         }, true);
                     }
                 }


### PR DESCRIPTION
When using this directive as a range slider (i.e. setting range=true) bootstrap-slider plugin throws an error because it is expecting an array [min,max], not a float.

I just added a logic in ngModelDeregisterFn to not convert the ngModel value to float if the slider is a range slider.