### PR TITLE
When using libraries such as bootstrap, you'll often want to have the…

### DIFF
--- a/slider.js
+++ b/slider.js
@@ -3,7 +3,7 @@ angular.module('ui.bootstrap-slider', [])
         return {
             restrict: 'AE',
             replace: true,
-            template: '<div><input class="slider-input" type="text" /></div>',
+            template: '<div><input class="slider-input" type="text" style="width:100%" /></div>',
             require: 'ngModel',
             scope: {
                 max: "=",


### PR DESCRIPTION
… slider size to its container instead of using its own arbitrary size. By setting the width of the input to 100%, we can force the slider to size to its container.

Before: http://plnkr.co/edit/rlg1yjrMQlOJQElsr3QB?p=preview

After: http://plnkr.co/edit/5sZXa3l9IW4HOfIuby82?p=preview