### PR TITLE
Take zero as a valid value when setting float option

### DIFF
--- a/slider.js
+++ b/slider.js
@@ -37,7 +37,7 @@ angular.module('ui.bootstrap-slider', [])
                     }
 
                     function setFloatOption(key, value, defaultValue) {
-                        options[key] = value ? parseFloat(value) : defaultValue;
+                        options[key] = value || value === 0 ? parseFloat(value) : defaultValue;
                     }
 
                     function setBooleanOption(key, value, defaultValue) {


### PR DESCRIPTION
When the max value for the slider is 0, it is taking the default value (since the condition checked falsy values). I just added a condition to determine whether the value is zero.