### PR TITLE
quick fix in test

### DIFF
--- a/test.html
+++ b/test.html
@@ -76,7 +76,7 @@
             orientation="{{ testOptions.orientation }}"
             handle="{{ testOptions.handle }}"
             enabled="{{ testOptions.enabled }}"
-            ng-disabled="{{ testOptions.ngDisabled }}"
+            ng-disabled="testOptions.ngDisabled"
             naturalarrowkeys="{{ testOptions.naturalarrowkeys }}"
             >
         If you can see this then slider did not get compiled by Angular.


### PR DESCRIPTION
Syntax Error: Token '{' invalid key at column 2 of the expression [{{ testOptions.ngDisabled }}] starting at [{ testOptions.ngDisabled }}].