### PR TITLE
event callbacks not triggered due to attribute naming issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,9 @@ But, if the `tooltip` attribute is in conflict with another angular directive, y
 <!-- it can be used as an element -->
 <slider ng-model="sliders.sliderValue" min="testOptions.min" step="testOptions.step" max="testOptions.max" value="testOptions.value" slider-tooltip="hide"></slider>
 ```
+
+#### Event Calbacks
+```html
+<!-- event callbacks receive the name of the event and the associated value with that event -->
+<slider ng-model="sliders.sliderValue" onSlideStop="myCallback($event,value)"></slider>
+```

--- a/slider.js
+++ b/slider.js
@@ -160,11 +160,11 @@ angular.module('ui.bootstrap-slider', [])
                         slideStop: 'onStopSlide'
                     };
                     angular.forEach(sliderEvents, function (sliderEventAttr, sliderEvent) {
-                        var fn = $parse(attrs[sliderEventAttr]);
+                        var fn = $parse(attrs[sliderEventAttr.toLowerCase()]);
                         slider.on(sliderEvent, function (ev) {
                             if ($scope[sliderEventAttr]) {
                                 $scope.$apply(function () {
-                                    fn($scope.$parent, { $event: ev, value: ev });
+                                    fn($scope.$parent, { $event: sliderEvent, value: ev });
                                 });
                             }
                         });


### PR DESCRIPTION
angular directive's link function gets 'attrs' with normalized names (ie lowercase, without dashes) even though in the local  it's case sensative. also, send the name of the event along with the event value to the callback