### PR TITLE
Bump version

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-bootstrap-slider",
-  "version": "0.1.8",
+  "version": "0.1.24",
   "authors": [
     "Kyle Kemp <kyle@seiyria.com>"
   ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-bootstrap-slider",
-  "version": "0.1.8",
+  "version": "0.1.24",
   "description": "An angular directive for seiyria-bootstrap-slider",
   "main": "slider.js",
   "dependencies": {


### PR DESCRIPTION
Let's bump version and create new release to match bower version, right now "bower info angular-bootstrap-slider" says that latest versions is 0.1.23 while configuration says something different.
