### PR TITLE
Adding support for AMD & CommonJS.

### DIFF
--- a/slider.js
+++ b/slider.js
@@ -1,3 +1,13 @@
+(function(factory) {
+    if (typeof define === 'function' && define.amd) {
+        define(['angular', 'bootstrapSlider'], factory);
+    } else if (typeof module === 'object' && module.exports) {
+        module.exports = factory(require('angular'), require('bootstrapSlider'));
+    } else if (window) {
+        factory(window.angular, window.Slider);
+    }
+})(function (angular, Slider) {
+
 angular.module('ui.bootstrap-slider', [])
     .directive('slider', ['$parse', '$timeout', '$rootScope', function ($parse, $timeout, $rootScope) {
         return {
@@ -219,3 +229,4 @@ angular.module('ui.bootstrap-slider', [])
         };
     }])
 ;
+});


### PR DESCRIPTION
This directive doesn't work for application built on AMD or CommonJs. If you take a look at source of bootstrap-slider.js (The actual plugin not the direcitve).

```
    if (typeof define === "function" && define.amd) {
        define(["jquery"], factory);
    } else if ((typeof module === "undefined" ? "undefined" : _typeof(module)) === "object" && module.exports) {
        var jQuery;
        try {
            jQuery = require("jquery");
        } catch (err) {
            jQuery = null;
        }
        module.exports = factory(jQuery);
    } else if (window) {
        window.Slider = factory(window.jQuery);
    }
```

Your code depends on `window.Slider` and hence only works in case if you are not using any AMD or CommonJs loader. This commit fixes the issue.