### PR TITLE
Watch the ticks array for changes

### DIFF
--- a/slider.js
+++ b/slider.js
@@ -210,7 +210,7 @@ angular.module('ui.bootstrap-slider', [])
                 }
 
 
-                var watchers = ['min', 'max', 'step', 'range', 'scale', 'ticksLabels'];
+                var watchers = ['min', 'max', 'step', 'range', 'scale', 'ticksLabels', 'ticks'];
                 angular.forEach(watchers, function (prop) {
                     $scope.$watch(prop, function () {
                         slider = initSlider();


### PR DESCRIPTION
Changing the ticks array does not result in changes in the slider. This is useful because when ticks is set dynamically using the ticks array. The use case is the same as when the min/max properties are used. The `ticks` property overwrites the min/max property of slider which is already watched for.