### PR TITLE
tooltip positioning fix

### DIFF
--- a/slider.js
+++ b/slider.js
@@ -65,7 +65,7 @@ angular.module('ui.bootstrap-slider', [])
                     setOption('selection', attrs.selection, 'before');
                     setOption('handle', attrs.handle, 'round');
                     setOption('tooltip', attrs.sliderTooltip || attrs.tooltip, 'show');
-                    setOption('tooltip_position', attrs.sliderTooltipPosition, 'top');
+                    setOption('tooltip_position', attrs.sliderTooltipPosition || attrs.slidertooltipposition, 'top');
                     setOption('tooltipseparator', attrs.tooltipseparator, ':');
                     setOption('ticks', $scope.ticks);
                     setOption('ticks_labels', $scope.ticksLabels);


### PR DESCRIPTION
The sliderTooltipPosition attr property for tooltip positioning was camel cased, preventing placement. This fix lowercases the property.