### PR TITLE
Update slider.js to prevent angular from being undefined when using r…

### DIFF
--- a/slider.js
+++ b/slider.js
@@ -1,12 +1,12 @@
 (function(factory) {
     if (typeof define === 'function' && define.amd) {
-        define(['angular', 'bootstrap-slider'], factory);
+        define(['bootstrap-slider', 'angular'], factory);
     } else if (typeof module === 'object' && module.exports) {
-        module.exports = factory(require('angular'), require('bootstrap-slider'));
+        module.exports = factory(require('bootstrap-slider'), require('angular'));
     } else if (window) {
-        factory(window.angular, window.Slider);
+        factory(window.Slider);
     }
-})(function (angular, Slider) {
+})(function (Slider) {
 
 angular.module('ui.bootstrap-slider', [])
     .directive('slider', ['$parse', '$timeout', '$rootScope', function ($parse, $timeout, $rootScope) {


### PR DESCRIPTION
While using requireJS and trying to bootstrap the app with ui.bootstrap-slider angular was becoming undefined.  Set up the following [plunker ](https://plnkr.co/edit/ryYbix9hfYNVYco2sfga?p=preview) for this to showcase that it is indeed getting undefined. Currently it is loading up the previous version of slider.js (labeled as ui.bootstrap-slider.js) and my updated version is sitting on there (ui.bootstrap-slider-update.js) just commented out. You can see that 'Cannot read property 'module' of undefined' is currently being thrown while bootstrapping. Angular is already defined at this point and passing it into the function is overriding angular causing it to be undefined.