### PR TITLE
Fix for passing scale attribute value to initSlider()

### DIFF
--- a/slider.js
+++ b/slider.js
@@ -74,7 +74,7 @@ angular.module('ui.bootstrap-slider', [])
                     setOption('ticks_positions', $scope.ticksPositions);
                     setOption('ticks_tooltip', $scope.ticksTooltip, false);
                     setOption('rangeHighlights', $scope.rangeHighlights);
-                    setOption('scale', $scope.scale, 'linear');
+                    setOption('scale', $scope.scale || attrs.scale, 'linear');
                     setOption('focus', $scope.focus);
 
                     setFloatOption('min', $scope.min, 0);


### PR DESCRIPTION
I can't pass scale = 'logarithmic' to the slider. After tracing the codes for so long, still no hints. Therefore, I added attrs.scale to set the scale option when $scope.scale is not available.