### PR TITLE
Check if jquery is defined

### DIFF
--- a/slider.js
+++ b/slider.js
@@ -130,7 +130,7 @@ angular.module('ui.bootstrap-slider', [])
                     }
 
                     // check if slider jQuery plugin exists
-                    if ('$' in window && $.fn.slider) {
+                    if (typeof window.$ !== 'undefined' && typeof $.fn === 'object' && $.fn.slider)
                         // adding methods to jQuery slider plugin prototype
                         $.fn.slider.constructor.prototype.disable = function () {
                             this.picker.off();

--- a/slider.js
+++ b/slider.js
@@ -130,7 +130,7 @@ angular.module('ui.bootstrap-slider', [])
                     }
 
                     // check if slider jQuery plugin exists
-                    if (typeof window.$ !== 'undefined' && typeof $.fn === 'object' && $.fn.slider)
+                    if (typeof window.$ !== 'undefined' && typeof $.fn === 'object' && $.fn.slider) {
                         // adding methods to jQuery slider plugin prototype
                         $.fn.slider.constructor.prototype.disable = function () {
                             this.picker.off();


### PR DESCRIPTION
When $ exists in window, but not defined, an error would occur.
This checks whether it's actually defined before calling its function `$.fn.slider`