### PR TITLE
Fix warning: $.fn.slider namespace is already bound. Use the $.fn.bootstrapSlider namespace instead.

### DIFF
--- a/slider.js
+++ b/slider.js
@@ -115,7 +115,7 @@ angular.module('ui.bootstrap-slider', [])
                             }
                         }
                         else {
-                            options.value = [options.min, options.max]; // This is needed, because of value defined at $.fn.slider.defaults - default value 5 prevents creating range slider
+                            options.value = [options.min, options.max]; // This is needed, because of value defined at $.fn.bootstrapSlider.defaults - default value 5 prevents creating range slider
                         }
                         $scope.ngModel = options.value; // needed, otherwise turns value into [null, ##]
                     }
@@ -130,12 +130,12 @@ angular.module('ui.bootstrap-slider', [])
                     }
 
                     // check if slider jQuery plugin exists
-                    if (typeof window.$ !== 'undefined' && typeof $.fn === 'object' && $.fn.slider) {
+                    if (typeof window.$ !== 'undefined' && typeof $.fn === 'object' && $.fn.bootstrapSlider) {
                         // adding methods to jQuery slider plugin prototype
-                        $.fn.slider.constructor.prototype.disable = function () {
+                        $.fn.bootstrapSlider.constructor.prototype.disable = function () {
                             this.picker.off();
                         };
-                        $.fn.slider.constructor.prototype.enable = function () {
+                        $.fn.bootstrapSlider.constructor.prototype.enable = function () {
                             this.picker.on();
                         };
                     }


### PR DESCRIPTION
Screenshot of warning in console: https://d2ffutrenqvap3.cloudfront.net/items/1Z3M1y0U2Z0Q0g0a1P12/Image%202018-01-10%20at%201.07.55%20PM.png?v=210d58ee