### PR TITLE
update dependency of bootstrap-slider to 10.5.0 and test new feature

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "karma-chrome-launcher": "^0.2.1",
     "karma-jasmine": "^0.3.6",
     "protractor": "^5.4.1",
-    "bootstrap-slider": "^10.3.2",
+    "bootstrap-slider": "^10.5.0",
     "angular": ">= 1.3 <=1.7",
     "bootstrap": "~3.3.6",
     "jquery": "3.3.1"

--- a/slider.js
+++ b/slider.js
@@ -35,7 +35,8 @@ angular.module('ui.bootstrap-slider', [])
                 formatter: '&',
                 onStartSlide: '&',
                 onStopSlide: '&',
-                onSlide: '&'
+                onSlide: '&',
+                lockToTicks: '='
             },
             link: function ($scope, element, attrs, ngModelCtrl, $compile) {
                 var ngModelDeregisterFn, ngDisabledDeregisterFn;
@@ -76,6 +77,7 @@ angular.module('ui.bootstrap-slider', [])
                     setOption('rangeHighlights', $scope.rangeHighlights);
                     setOption('scale', $scope.scale, 'linear');
                     setOption('focus', $scope.focus);
+                    setOption('lock_to_ticks', $scope.lockToTicks, false);
 
                     setFloatOption('min', $scope.min, 0);
                     setFloatOption('max', $scope.max, 10);

--- a/test.html
+++ b/test.html
@@ -198,6 +198,15 @@
     <span slider ng-model="model.tenth"
           updateevent="[&quot;slideStop&quot;, &quot;slide&quot;, &quot;slideStart&quot;]"></span>
     Model: {{model.tenth}}
+
+    <br><br>
+    Lock to ticks
+    <span slider
+          ng-model="model.eleventh"
+          ticks="[3, 5, 7]"
+          lock_to_ticks="true"></span>
+    Model: {{model.eleventh}}
+
 </div>
 
 

--- a/test.js
+++ b/test.js
@@ -30,7 +30,8 @@ angular.module('angular-bootstrap-slider-test', ['ui.bootstrap-slider'])
             seventh: 0,
             eighth: 0,
             ninth: 0,
-            tenth: 0
+            tenth: 0,
+            eleventh: 3
         };
 
         $scope.value = {
@@ -43,7 +44,8 @@ angular.module('angular-bootstrap-slider-test', ['ui.bootstrap-slider'])
             seventh: 0,
             eighth: 0,
             ninth: 0,
-            tenth: 0
+            tenth: 0,
+            eleventh: 3
         };
 
         $scope.prefix = 'Current value: ';


### PR DESCRIPTION
The version of Bootstrap-Slider 10.5.0 has the new lock-to-ticks feature.  
I have updated the dependency version in package.json and added the new feature "lock-to-ticks" in slider.js. I also created a slider with this new feature in test.html page to make sure it works as expected.  
![image](https://user-images.githubusercontent.com/15864898/55887210-1bfa3c00-5b7b-11e9-8707-e18686ed7edd.png)
