### PR TITLE
update version number

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-bootstrap-slider",
-  "version": "0.1.26",
+  "version": "0.1.29",
   "description": "An angular directive for seiyria-bootstrap-slider",
   "main": "slider.js",
   "devDependencies": {


### PR DESCRIPTION
Someone forgot to update the version number to 0.1.28, which is causing issues with npm.

I suggest publishing a new version 0.1.29 to npm with the version number updated to 0.1.29.